### PR TITLE
Add agent.type to published assets and change the asset.kind of pods to container_group

### DIFF
--- a/x-pack/plugins/asset_manager/common/types_api.ts
+++ b/x-pack/plugins/asset_manager/common/types_api.ts
@@ -14,11 +14,11 @@ export const assetTypeRT = rt.union([
 ]);
 
 export type AssetType = rt.TypeOf<typeof assetTypeRT>;
-
+export type AgentType = 'implicit_collector';
 export const assetKindRT = rt.union([
   rt.literal('cluster'),
   rt.literal('host'),
-  rt.literal('pod'),
+  rt.literal('container_group'),
   rt.literal('container'),
   rt.literal('service'),
   rt.literal('alert'),
@@ -79,6 +79,7 @@ export interface Asset extends ECSDocument {
   'asset.namespace'?: string;
   'host.hostname'?: string;
   'host.id'?: string;
+  'agent.type'?: AgentType;
 }
 
 export type AssetWithoutTimestamp = Omit<Asset, '@timestamp'>;

--- a/x-pack/plugins/asset_manager/server/lib/collectors/containers.ts
+++ b/x-pack/plugins/asset_manager/server/lib/collectors/containers.ts
@@ -74,6 +74,7 @@ export async function collectContainers({
       'asset.id': containerId,
       'asset.ean': `container:${containerId}`,
       'asset.parents': [parentEan],
+      'agent.type': 'implicit_collector'
     };
 
     if (nodeName) {

--- a/x-pack/plugins/asset_manager/server/lib/collectors/hosts.ts
+++ b/x-pack/plugins/asset_manager/server/lib/collectors/hosts.ts
@@ -89,6 +89,7 @@ export async function collectK8sNodes({
       'asset.ean': hostEan,
       'kubernetes.node.uid': nodeUid,
       'kubernetes.node.name': nodeName,
+      'agent.type': 'implicit_collector'
     };
 
     if (hostId) {
@@ -202,6 +203,7 @@ export async function collectCloudHosts({
       'asset.name': instanceId,
       'asset.ean': hostEan,
       'asset.children': [],
+      'agent.type': 'implicit_collector'
     };
 
     if (hostId) {
@@ -317,6 +319,7 @@ export async function collectHostsById({
       'asset.name': hostId,
       'asset.ean': hostEan,
       'asset.children': [],
+      'agent.type': 'implicit_collector'
     };
 
     if (hostName) {
@@ -405,6 +408,7 @@ export async function collectHostsByName({
       'asset.ean': hostEan,
       'host.hostname': hostName,
       'asset.children': [],
+      'agent.type': 'implicit_collector'
     };
 
     if (fields['orchestrator.cluster.name']) {

--- a/x-pack/plugins/asset_manager/server/lib/collectors/pods.ts
+++ b/x-pack/plugins/asset_manager/server/lib/collectors/pods.ts
@@ -60,10 +60,11 @@ export async function collectPods({ client, from, to, sourceIndices, afterKey }:
 
     const pod: Asset = {
       '@timestamp': new Date().toISOString(),
-      'asset.kind': 'pod',
+      'asset.kind': 'container_group',
       'asset.id': podUid,
       'asset.ean': `pod:${podUid}`,
       'asset.parents': [`host:${nodeName}`],
+      'agent.type': 'implicit_collector'
     };
 
     if (fields['cloud.provider']) {


### PR DESCRIPTION
## Summary

- Add `agent.type=='implicit_collector'` to all published documents
- Change `asset.type` for pods from `pod` to `container_group`  as we in assetbeat 